### PR TITLE
Use OpenHab native javascript logger

### DIFF
--- a/lib/openHAB/ruleBasedInterpreter.js
+++ b/lib/openHAB/ruleBasedInterpreter.js
@@ -159,12 +159,12 @@ class CommandExp extends Expression {
 
         var executeFunction = function(parameter) {
             if (!parameter || typeof(parameter) != "object") {
-                logger.info("Trying to send a command, but no proper object parameter found")
+                logger.debug("Trying to send a command, but no proper object parameter found")
                 return;
             }
 
             if (!parameter.items) {
-                logger.info("Trying to send a command, but no items parameter found")
+                logger.debug("Trying to send a command, but no items parameter found")
                 return;
             }
 
@@ -262,18 +262,18 @@ class ItemPropertiesExp extends Expression {
         logger.debug("eval item properties with tokens: " + stringify(tokens))
 
         if (tokens.length < 1) {
-            logger.info("no tokens, eval item properties fail")
+            logger.debug("no tokens, eval item properties fail")
             return new EvaluationResult(false, tokens, null, null);
         }
 
         let expResult = evaluateExpressionOrString(this.value, tokens.slice());
         if (!expResult.success) {
-            logger.info("eval item properties: inner expression eval fail");
+            logger.debug("eval item properties: inner expression eval fail");
             return new EvaluationResult(false, tokens, null, null);
         }
 
         if (this.groupRequired && expResult.groupItem == null) {
-            logger.info("eval item properties fail: group required but not found");
+            logger.debug("eval item properties fail: group required but not found");
             return new EvaluationResult(false, tokens, null, null);
         }
 
@@ -551,7 +551,7 @@ function getItemByLabelOrSynonym(itemList, tokens) {
         return {matchedItem: matchResult.remainingItems[0].item, remainingTokens: tokens.slice(matchResult.tokenIndex)};
     }
 
-    logger.info("get item by label: fail");
+    logger.debug("get item by label: fail");
     return null;
 }
 

--- a/lib/openHAB/ruleBasedInterpreter.js
+++ b/lib/openHAB/ruleBasedInterpreter.js
@@ -1,8 +1,9 @@
 const { items } = require('openhab');
+let logger = require('openhab').log('cuevox');
 
 class Expression {
     /**
-     * @param {string[]} tokens 
+     * @param {string[]} tokens
      * @returns {EvaluationResult}
      */
     evaluate(tokens) {
@@ -17,7 +18,7 @@ class Expression {
 function alt(...expressions) {return new AlternativeExp(...expressions);}
 class AlternativeExp extends Expression {
     /**
-     * @param  {...Expression} expressions 
+     * @param  {...Expression} expressions
      */
     constructor(...expressions) {
         super();
@@ -25,8 +26,8 @@ class AlternativeExp extends Expression {
     }
 
     evaluate(tokens) {
-        console.debug("eval alt: " + stringify(this.value));
-        console.debug("for tokens: " + stringify(tokens));
+        logger.debug("eval alt: " + stringify(this.value));
+        logger.debug("for tokens: " + stringify(tokens));
 
         var success = false;
         var executeFunction = null;
@@ -36,7 +37,7 @@ class AlternativeExp extends Expression {
 
         for (var index = 0; index < this.value.length; index++) {
             var subexp = this.value[index];
-            console.debug("alt index: " + index + "; subexp: " + stringify(subexp));
+            logger.debug("alt index: " + index + "; subexp: " + stringify(subexp));
             var result = evaluateExpressionOrString(subexp, tokens.slice());
             if (result.success) {
                 success = true;
@@ -47,8 +48,8 @@ class AlternativeExp extends Expression {
                 break;
             }
         }
-        
-        console.debug("eval alt: " + success)
+
+        logger.debug("eval alt: " + success)
         return new EvaluationResult(success, remainingTokens, executeFunction, executeParameter);
     }
 }
@@ -60,7 +61,7 @@ class AlternativeExp extends Expression {
 function seq(...expressions) {return new SequenceExp(...expressions);}
 class SequenceExp extends Expression {
     /**
-     * @param  {...Expression} expressions 
+     * @param  {...Expression} expressions
      */
     constructor(...expressions) {
         super();
@@ -68,7 +69,7 @@ class SequenceExp extends Expression {
     }
 
     evaluate(tokens) {
-        console.debug("eval seq: " + stringify(this.value));
+        logger.debug("eval seq: " + stringify(this.value));
         var success = true;
         var executeFunction = null;
         var executeParameter = null;
@@ -78,10 +79,10 @@ class SequenceExp extends Expression {
 
         for (var index = 0; index < this.value.length; index++) {
             var subexp = this.value[index];
-            console.debug("eval subexp " + index + "; subexp: " + stringify(subexp))
+            logger.debug("eval subexp " + index + "; subexp: " + stringify(subexp))
             var result = evaluateExpressionOrString(subexp, remainingTokens);
             if (!result.success) {
-                console.debug("eval subexp " + index + "failed");
+                logger.debug("eval subexp " + index + "failed");
                 success = false;
                 break;
             }
@@ -91,21 +92,21 @@ class SequenceExp extends Expression {
             executeParameter = result.executeParameter || executeParameter;
             groupItem = result.groupItem || groupItem;
         }
-        
-        console.debug("eval seq: " + success)
+
+        logger.debug("eval seq: " + success)
         return new EvaluationResult(success, remainingTokens, executeFunction, executeParameter, groupItem);
     }
 }
 
 /**
  * Creates an optional expression. The given expression is not mandatory for a match.
- * @param  {Expression} expression 
+ * @param  {Expression} expression
  */
 function opt(expression) {return new OptionalExp(expression);}
 class OptionalExp extends Expression {
     /**
-     * 
-     * @param {Expression} expression 
+     *
+     * @param {Expression} expression
      */
     constructor(expression) {
         super();
@@ -113,15 +114,15 @@ class OptionalExp extends Expression {
     }
 
     evaluate(tokens) {
-        console.debug("eval opt: " + stringify(this.value))
+        logger.debug("eval opt: " + stringify(this.value))
         var result = evaluateExpressionOrString(this.value, tokens.slice());
         if (result.success) {
-            console.debug("eval opt success")
+            logger.debug("eval opt success")
             // only return the reduced token array and other parameters if optional expression was successful.
             return new EvaluationResult(true, result.remainingTokens, result.executeFunction, result.executeParameter);
         }
-        
-        console.debug("eval opt fail")
+
+        logger.debug("eval opt fail")
         // otherwise still return successful, but nothing from the optional expression result
         return new EvaluationResult(true, tokens, null, null);
     }
@@ -130,14 +131,14 @@ class OptionalExp extends Expression {
 /**
  * Creates a command expression.
  * If the given expression is matched, the given command is sent to all found items of that rule.
- * @param {Expression} expression 
- * @param {string} command 
+ * @param {Expression} expression
+ * @param {string} command
  */
 function cmd(expression, command) {return new CommandExp(expression, command);}
 class CommandExp extends Expression {
     /**
-     * @param {Expression} expression 
-     * @param {string} command 
+     * @param {Expression} expression
+     * @param {string} command
      */
     constructor(expression, command) {
         super();
@@ -146,10 +147,10 @@ class CommandExp extends Expression {
     }
 
     evaluate(tokens) {
-        console.debug("eval cmd: " + stringify(this.value));
+        logger.debug("eval cmd: " + stringify(this.value));
         var result = evaluateExpressionOrString(this.value, tokens);
-        
-        console.debug("eval cmd result: " + result.success)
+
+        logger.debug("eval cmd result: " + result.success)
         if (!result.success) {
             return new EvaluationResult(false, tokens, null, null);
         }
@@ -158,17 +159,17 @@ class CommandExp extends Expression {
 
         var executeFunction = function(parameter) {
             if (!parameter || typeof(parameter) != "object") {
-                console.debug("Trying to send a command, but no proper object parameter found")
+                logger.info("Trying to send a command, but no proper object parameter found")
                 return;
             }
-            
+
             if (!parameter.items) {
-                console.debug("Trying to send a command, but no items parameter found")
+                logger.info("Trying to send a command, but no items parameter found")
                 return;
             }
 
             parameter.items.forEach(item => {
-                item.sendCommand(commandToExecute); 
+                item.sendCommand(commandToExecute);
             });
         }
         return new EvaluationResult(true, result.remainingTokens, executeFunction, result.executeParameter);
@@ -182,7 +183,7 @@ class CommandExp extends Expression {
  * The found item can be included in the final execution parameter, e.g. to send a command to that item.
  * @param {boolean} includeInExecuteParameter   Default: true.
  * @param {boolean} isGroup                     Default: false. If true, only group items (type: "Group") are matched.
- * @returns 
+ * @returns
  */
 function itemLabel(includeInExecuteParameter, isGroup) {return new ItemLabelExp(includeInExecuteParameter, isGroup);}
 class ItemLabelExp extends Expression {
@@ -197,10 +198,10 @@ class ItemLabelExp extends Expression {
     }
 
     evaluate(tokens) {
-        console.debug("eval item label with tokens: " + stringify(tokens))
-        
+        logger.debug("eval item label with tokens: " + stringify(tokens))
+
         if (tokens.length < 1) {
-            console.debug("no tokens, eval item label fail")
+            logger.debug("no tokens, eval item label fail")
             return new EvaluationResult(false, tokens, null, null);
         }
 
@@ -212,11 +213,11 @@ class ItemLabelExp extends Expression {
         let matchResult = getItemByLabelOrSynonym(remainingItems, tokens);
 
         if (!matchResult) {
-            console.debug("eval item label fail");
+            logger.debug("eval item label fail");
             return new EvaluationResult(false, tokens, null, null);
         }
 
-        console.debug("eval item label success")
+        logger.debug("eval item label success")
         let groupItem = null;
         if (this.isGroup) {
             groupItem = matchResult.matchedItem;
@@ -244,9 +245,9 @@ class ItemLabelExp extends Expression {
 function itemProperties(expression, tags, groupRequired, itemType) {return new ItemPropertiesExp(expression, tags, groupRequired, itemType);}
 class ItemPropertiesExp extends Expression {
     /**
-     * @param {Expression} expression 
-     * @param {string[]} tags 
-     * @param {boolean} groupRequired 
+     * @param {Expression} expression
+     * @param {string[]} tags
+     * @param {boolean} groupRequired
      * @param {string} itemType
      */
     constructor(expression, tags, groupRequired, itemType) {
@@ -258,43 +259,43 @@ class ItemPropertiesExp extends Expression {
     }
 
     evaluate(tokens) {
-        console.debug("eval item properties with tokens: " + stringify(tokens))
-        
+        logger.debug("eval item properties with tokens: " + stringify(tokens))
+
         if (tokens.length < 1) {
-            console.debug("no tokens, eval item properties fail")
+            logger.info("no tokens, eval item properties fail")
             return new EvaluationResult(false, tokens, null, null);
         }
 
         let expResult = evaluateExpressionOrString(this.value, tokens.slice());
         if (!expResult.success) {
-            console.debug("eval item properties: inner expression eval fail");
+            logger.info("eval item properties: inner expression eval fail");
             return new EvaluationResult(false, tokens, null, null);
         }
 
         if (this.groupRequired && expResult.groupItem == null) {
-            console.debug("eval item properties fail: group required but not found");
+            logger.info("eval item properties fail: group required but not found");
             return new EvaluationResult(false, tokens, null, null);
         }
 
-        console.debug("eval item properties: search items");
+        logger.debug("eval item properties: search items");
 
         let remainingItems = null;
         if (this.tags.length == 0) {
             remainingItems = items.getItems();
-            console.debug("eval item properties: get all items");
+            logger.debug("eval item properties: get all items");
         } else {
             remainingItems = items.getItemsByTag(...this.tags);
-            console.debug("eval item properties: filter items by tags: " + this.tags + "; remaining: " + remainingItems.length);
+            logger.debug("eval item properties: filter items by tags: " + this.tags + "; remaining: " + remainingItems.length);
         }
 
         if (this.itemType != null) {
             remainingItems = remainingItems.filter(item => item.type == this.itemType);
-            console.debug("eval item properties: filter items by type: " + this.itemType + "; remaining: " + remainingItems.length);
+            logger.debug("eval item properties: filter items by type: " + this.itemType + "; remaining: " + remainingItems.length);
         }
-        
+
         if (this.groupRequired) {
             remainingItems = remainingItems.filter(item => itemIsInSubGroup(item, expResult.groupItem));
-            console.debug("eval item properties: filter items by group: " + expResult.groupItem.name + "; remaining: " + remainingItems.length);
+            logger.debug("eval item properties: filter items by group: " + expResult.groupItem.name + "; remaining: " + remainingItems.length);
         }
 
         if (!expResult.executeParameter) {
@@ -312,12 +313,12 @@ class ItemPropertiesExp extends Expression {
 
 class EvaluationResult {
     /**
-     * 
+     *
      * @param {boolean} success             if evaluation was successful or not
-     * @param {string[]} remainingTokens 
-     * @param {function} executeFunction    the function to execute in the end 
+     * @param {string[]} remainingTokens
+     * @param {function} executeFunction    the function to execute in the end
      * @param {object} executeParameter     the parameter inserted in the executeFunction. Should be a single object that can hold multiple parameters in its key/value pairs.
-     * @param {object} groupItem 
+     * @param {object} groupItem
      */
     constructor(success, remainingTokens, executeFunction, executeParameter, groupItem) {
         this.success = success;
@@ -340,7 +341,7 @@ class RuleBasedInterpreter {
     /**
      * Adds a rule.
      * Either the expression must contain a function to execute (e.g. send a command) or a specific function must be given.
-     * @param {Expression} expression 
+     * @param {Expression} expression
      * @param {function} executeFunction    If a specific function is given, it will override any function from the expression.
      */
     addRule(expression, executeFunction) {
@@ -359,8 +360,8 @@ class RuleBasedInterpreter {
 
     /**
      * Tries to interpret the given utterance by matching all saved rules.
-     * @param {string} utterance 
-     * @returns 
+     * @param {string} utterance
+     * @returns
      */
     interpretUtterance(utterance) {
         if (!utterance) {
@@ -370,34 +371,32 @@ class RuleBasedInterpreter {
         var normalizedUtterance = normalizeUtterance(utterance);
         var tokens = tokenizeUtterance(normalizedUtterance);
 
-        console.debug("input normalized utterance: " + normalizedUtterance);
-        console.debug("input tokens: " + stringify(tokens));
+        logger.debug("input normalized utterance: " + normalizedUtterance);
+        logger.debug("input tokens: " + stringify(tokens));
 
         for (var index = 0; index < this.rules.length; index++) {
-            console.debug("check rule " + index);
+            logger.debug("check rule " + index);
             var rule = this.rules[index];
-            console.debug(stringify(rule));
+            logger.debug(stringify(rule));
             var result = evaluateExpressionOrString(rule.expression, tokens.slice());
             if (result.success) {
                 var executeFunction = result.executeFunction || rule.executeFunction;
                 if (!executeFunction) {
-                    console.debug("rule matched, but no function to execute found, continue");
+                    logger.debug("rule matched, but no function to execute found, continue");
                     continue;
                 }
 
                 executeFunction(result.executeParameter);
                 break;
             }
-        }        
+        }
     }
-
-    
 }
 
 /**
- * 
- * @param {Expression} expression 
- * @param {string[]} tokens 
+ *
+ * @param {Expression} expression
+ * @param {string[]} tokens
  * @returns {EvaluationResult}
  */
 function evaluateExpressionOrString(expression, tokens) {
@@ -417,10 +416,10 @@ function evaluateStringExpression(expression, tokens) {
         return new EvaluationResult(false, tokens, null, null);
     }
 
-    console.debug("eval string: " + expression)
-    console.debug("token: " + tokens[0]);
+    logger.debug("eval string: " + expression)
+    logger.debug("token: " + tokens[0]);
     var hasMatch = tokens[0] === expression; //tokens[0].match(expression) != null;
-    console.debug("hasMatch: " + hasMatch)
+    logger.debug("hasMatch: " + hasMatch)
     return new EvaluationResult(hasMatch, tokens.slice(1), null, null);
 }
 
@@ -455,7 +454,7 @@ function getItemByLabelOrSynonym(itemList, tokens) {
     // first try the regular labels
     let checkLabels = function(remainingItems) {
         let tokenIndex = 0;
-        
+
         while (remainingItems.length > 1) {
             if (tokens.length < tokenIndex + 1) {
                 // no tokens left, but still multiple possible items -> abort
@@ -502,13 +501,13 @@ function getItemByLabelOrSynonym(itemList, tokens) {
             });
 
             let tokenIndex = 0;
-            
+
             while (remainingItems.length > 1) {
                 if (tokens.length < tokenIndex + 1) {
                     // no tokens left, but still multiple possible items -> abort
                     break;
                 }
-    
+
                 // remove synonyms with fewer or non-matching tokens
                 remainingItems = remainingItems.map(function(i) {
                     i.synonyms = i.synonyms.filter(function(synonymTokens) {
@@ -516,12 +515,12 @@ function getItemByLabelOrSynonym(itemList, tokens) {
                     });
                     return i;
                 });
-                
+
                 // remove items without synonyms
                 remainingItems = remainingItems.filter(function(i) {
                     return i.synonyms.length > 0;
                 });
-                
+
                 tokenIndex++;
             }
 
@@ -544,15 +543,15 @@ function getItemByLabelOrSynonym(itemList, tokens) {
 
         matchResult = checkSynonyms(allItems.slice());
 
-        console.debug("get item by label: found matched synonyms: " + matchResult.remainingItems.length);
+        logger.debug("get item by label: found matched synonyms: " + matchResult.remainingItems.length);
     }
 
     if (matchResult.remainingItems.length == 1) {
-        console.debug("get item by label: success");
+        logger.debug("get item by label: success");
         return {matchedItem: matchResult.remainingItems[0].item, remainingTokens: tokens.slice(matchResult.tokenIndex)};
     }
 
-    console.debug("get item by label: fail");
+    logger.info("get item by label: fail");
     return null;
 }
 
@@ -596,7 +595,6 @@ function itemIsInSubGroup(item, targetGroupItem) {
                 checkedGroupNames.push(groupName);
                 groupStack.push(items.getItem(groupName));
             }
-            
         });
     }
 

--- a/rule-template/cuevox.yaml
+++ b/rule-template/cuevox.yaml
@@ -31,10 +31,11 @@ actions:
           // ***
 
           const { items } = require('openhab');
+          let logger = require('openhab').log('cuevox');
 
           class Expression {
               /**
-               * @param {string[]} tokens 
+               * @param {string[]} tokens
                * @returns {EvaluationResult}
                */
               evaluate(tokens) {
@@ -49,16 +50,16 @@ actions:
           function alt(...expressions) {return new AlternativeExp(...expressions);}
           class AlternativeExp extends Expression {
               /**
-               * @param  {...Expression} expressions 
-               */
+              * @param  {...Expression} expressions
+              */
               constructor(...expressions) {
                   super();
                   this.value = expressions;
               }
 
               evaluate(tokens) {
-                  console.debug("eval alt: " + stringify(this.value));
-                  console.debug("for tokens: " + stringify(tokens));
+                  logger.debug("eval alt: " + stringify(this.value));
+                  logger.debug("for tokens: " + stringify(tokens));
 
                   var success = false;
                   var executeFunction = null;
@@ -68,7 +69,7 @@ actions:
 
                   for (var index = 0; index < this.value.length; index++) {
                       var subexp = this.value[index];
-                      console.debug("alt index: " + index + "; subexp: " + stringify(subexp));
+                      logger.debug("alt index: " + index + "; subexp: " + stringify(subexp));
                       var result = evaluateExpressionOrString(subexp, tokens.slice());
                       if (result.success) {
                           success = true;
@@ -80,7 +81,7 @@ actions:
                       }
                   }
 
-                  console.debug("eval alt: " + success)
+                  logger.debug("eval alt: " + success)
                   return new EvaluationResult(success, remainingTokens, executeFunction, executeParameter);
               }
           }
@@ -92,7 +93,7 @@ actions:
           function seq(...expressions) {return new SequenceExp(...expressions);}
           class SequenceExp extends Expression {
               /**
-               * @param  {...Expression} expressions 
+               * @param  {...Expression} expressions
                */
               constructor(...expressions) {
                   super();
@@ -100,7 +101,7 @@ actions:
               }
 
               evaluate(tokens) {
-                  console.debug("eval seq: " + stringify(this.value));
+                  logger.debug("eval seq: " + stringify(this.value));
                   var success = true;
                   var executeFunction = null;
                   var executeParameter = null;
@@ -110,10 +111,10 @@ actions:
 
                   for (var index = 0; index < this.value.length; index++) {
                       var subexp = this.value[index];
-                      console.debug("eval subexp " + index + "; subexp: " + stringify(subexp))
+                      logger.debug("eval subexp " + index + "; subexp: " + stringify(subexp))
                       var result = evaluateExpressionOrString(subexp, remainingTokens);
                       if (!result.success) {
-                          console.debug("eval subexp " + index + "failed");
+                          logger.debug("eval subexp " + index + "failed");
                           success = false;
                           break;
                       }
@@ -124,20 +125,20 @@ actions:
                       groupItem = result.groupItem || groupItem;
                   }
 
-                  console.debug("eval seq: " + success)
+                  logger.debug("eval seq: " + success)
                   return new EvaluationResult(success, remainingTokens, executeFunction, executeParameter, groupItem);
               }
           }
 
           /**
            * Creates an optional expression. The given expression is not mandatory for a match.
-           * @param  {Expression} expression 
+           * @param  {Expression} expression
            */
           function opt(expression) {return new OptionalExp(expression);}
           class OptionalExp extends Expression {
               /**
-               * 
-               * @param {Expression} expression 
+               *
+               * @param {Expression} expression
                */
               constructor(expression) {
                   super();
@@ -145,15 +146,15 @@ actions:
               }
 
               evaluate(tokens) {
-                  console.debug("eval opt: " + stringify(this.value))
+                  logger.debug("eval opt: " + stringify(this.value))
                   var result = evaluateExpressionOrString(this.value, tokens.slice());
                   if (result.success) {
-                      console.debug("eval opt success")
+                      logger.debug("eval opt success")
                       // only return the reduced token array and other parameters if optional expression was successful.
                       return new EvaluationResult(true, result.remainingTokens, result.executeFunction, result.executeParameter);
                   }
 
-                  console.debug("eval opt fail")
+                  logger.debug("eval opt fail")
                   // otherwise still return successful, but nothing from the optional expression result
                   return new EvaluationResult(true, tokens, null, null);
               }
@@ -162,14 +163,14 @@ actions:
           /**
            * Creates a command expression.
            * If the given expression is matched, the given command is sent to all found items of that rule.
-           * @param {Expression} expression 
-           * @param {string} command 
+           * @param {Expression} expression
+           * @param {string} command
            */
           function cmd(expression, command) {return new CommandExp(expression, command);}
           class CommandExp extends Expression {
               /**
-               * @param {Expression} expression 
-               * @param {string} command 
+               * @param {Expression} expression
+               * @param {string} command
                */
               constructor(expression, command) {
                   super();
@@ -178,10 +179,10 @@ actions:
               }
 
               evaluate(tokens) {
-                  console.debug("eval cmd: " + stringify(this.value));
+                  logger.debug("eval cmd: " + stringify(this.value));
                   var result = evaluateExpressionOrString(this.value, tokens);
 
-                  console.debug("eval cmd result: " + result.success)
+                  logger.debug("eval cmd result: " + result.success)
                   if (!result.success) {
                       return new EvaluationResult(false, tokens, null, null);
                   }
@@ -190,17 +191,17 @@ actions:
 
                   var executeFunction = function(parameter) {
                       if (!parameter || typeof(parameter) != "object") {
-                          console.debug("Trying to send a command, but no proper object parameter found")
+                          logger.info("Trying to send a command, but no proper object parameter found")
                           return;
                       }
 
                       if (!parameter.items) {
-                          console.debug("Trying to send a command, but no items parameter found")
+                          logger.info("Trying to send a command, but no items parameter found")
                           return;
                       }
 
                       parameter.items.forEach(item => {
-                          item.sendCommand(commandToExecute); 
+                          item.sendCommand(commandToExecute);
                       });
                   }
                   return new EvaluationResult(true, result.remainingTokens, executeFunction, result.executeParameter);
@@ -214,7 +215,7 @@ actions:
            * The found item can be included in the final execution parameter, e.g. to send a command to that item.
            * @param {boolean} includeInExecuteParameter   Default: true.
            * @param {boolean} isGroup                     Default: false. If true, only group items (type: "Group") are matched.
-           * @returns 
+           * @returns
            */
           function itemLabel(includeInExecuteParameter, isGroup) {return new ItemLabelExp(includeInExecuteParameter, isGroup);}
           class ItemLabelExp extends Expression {
@@ -229,10 +230,10 @@ actions:
               }
 
               evaluate(tokens) {
-                  console.debug("eval item label with tokens: " + stringify(tokens))
+                  logger.debug("eval item label with tokens: " + stringify(tokens))
 
                   if (tokens.length < 1) {
-                      console.debug("no tokens, eval item label fail")
+                      logger.debug("no tokens, eval item label fail")
                       return new EvaluationResult(false, tokens, null, null);
                   }
 
@@ -244,11 +245,11 @@ actions:
                   let matchResult = getItemByLabelOrSynonym(remainingItems, tokens);
 
                   if (!matchResult) {
-                      console.debug("eval item label fail");
+                      logger.debug("eval item label fail");
                       return new EvaluationResult(false, tokens, null, null);
                   }
 
-                  console.debug("eval item label success")
+                  logger.debug("eval item label success")
                   let groupItem = null;
                   if (this.isGroup) {
                       groupItem = matchResult.matchedItem;
@@ -276,9 +277,9 @@ actions:
           function itemProperties(expression, tags, groupRequired, itemType) {return new ItemPropertiesExp(expression, tags, groupRequired, itemType);}
           class ItemPropertiesExp extends Expression {
               /**
-               * @param {Expression} expression 
-               * @param {string[]} tags 
-               * @param {boolean} groupRequired 
+               * @param {Expression} expression
+               * @param {string[]} tags
+               * @param {boolean} groupRequired
                * @param {string} itemType
                */
               constructor(expression, tags, groupRequired, itemType) {
@@ -290,43 +291,43 @@ actions:
               }
 
               evaluate(tokens) {
-                  console.debug("eval item properties with tokens: " + stringify(tokens))
+                  logger.debug("eval item properties with tokens: " + stringify(tokens))
 
                   if (tokens.length < 1) {
-                      console.debug("no tokens, eval item properties fail")
+                      logger.info("no tokens, eval item properties fail")
                       return new EvaluationResult(false, tokens, null, null);
                   }
 
                   let expResult = evaluateExpressionOrString(this.value, tokens.slice());
                   if (!expResult.success) {
-                      console.debug("eval item properties: inner expression eval fail");
+                      logger.info("eval item properties: inner expression eval fail");
                       return new EvaluationResult(false, tokens, null, null);
                   }
 
                   if (this.groupRequired && expResult.groupItem == null) {
-                      console.debug("eval item properties fail: group required but not found");
+                      logger.info("eval item properties fail: group required but not found");
                       return new EvaluationResult(false, tokens, null, null);
                   }
 
-                  console.debug("eval item properties: search items");
+                  logger.debug("eval item properties: search items");
 
                   let remainingItems = null;
                   if (this.tags.length == 0) {
                       remainingItems = items.getItems();
-                      console.debug("eval item properties: get all items");
+                      logger.debug("eval item properties: get all items");
                   } else {
                       remainingItems = items.getItemsByTag(...this.tags);
-                      console.debug("eval item properties: filter items by tags: " + this.tags + "; remaining: " + remainingItems.length);
+                      logger.debug("eval item properties: filter items by tags: " + this.tags + "; remaining: " + remainingItems.length);
                   }
 
                   if (this.itemType != null) {
                       remainingItems = remainingItems.filter(item => item.type == this.itemType);
-                      console.debug("eval item properties: filter items by type: " + this.itemType + "; remaining: " + remainingItems.length);
+                      logger.debug("eval item properties: filter items by type: " + this.itemType + "; remaining: " + remainingItems.length);
                   }
 
                   if (this.groupRequired) {
                       remainingItems = remainingItems.filter(item => itemIsInSubGroup(item, expResult.groupItem));
-                      console.debug("eval item properties: filter items by group: " + expResult.groupItem.name + "; remaining: " + remainingItems.length);
+                      logger.debug("eval item properties: filter items by group: " + expResult.groupItem.name + "; remaining: " + remainingItems.length);
                   }
 
                   if (!expResult.executeParameter) {
@@ -344,12 +345,12 @@ actions:
 
           class EvaluationResult {
               /**
-               * 
+               *
                * @param {boolean} success             if evaluation was successful or not
-               * @param {string[]} remainingTokens 
-               * @param {function} executeFunction    the function to execute in the end 
+               * @param {string[]} remainingTokens
+               * @param {function} executeFunction    the function to execute in the end
                * @param {object} executeParameter     the parameter inserted in the executeFunction. Should be a single object that can hold multiple parameters in its key/value pairs.
-               * @param {object} groupItem 
+               * @param {object} groupItem
                */
               constructor(success, remainingTokens, executeFunction, executeParameter, groupItem) {
                   this.success = success;
@@ -372,7 +373,7 @@ actions:
               /**
                * Adds a rule.
                * Either the expression must contain a function to execute (e.g. send a command) or a specific function must be given.
-               * @param {Expression} expression 
+               * @param {Expression} expression
                * @param {function} executeFunction    If a specific function is given, it will override any function from the expression.
                */
               addRule(expression, executeFunction) {
@@ -391,8 +392,8 @@ actions:
 
               /**
                * Tries to interpret the given utterance by matching all saved rules.
-               * @param {string} utterance 
-               * @returns 
+               * @param {string} utterance
+               * @returns
                */
               interpretUtterance(utterance) {
                   if (!utterance) {
@@ -402,36 +403,32 @@ actions:
                   var normalizedUtterance = normalizeUtterance(utterance);
                   var tokens = tokenizeUtterance(normalizedUtterance);
 
-                  console.debug("input normalized utterance: " + normalizedUtterance);
-                  console.debug("input tokens: " + stringify(tokens));
+                  logger.debug("input normalized utterance: " + normalizedUtterance);
+                  logger.debug("input tokens: " + stringify(tokens));
 
                   for (var index = 0; index < this.rules.length; index++) {
-                      console.debug("check rule " + index);
+                      logger.debug("check rule " + index);
                       var rule = this.rules[index];
-                      console.debug(stringify(rule));
+                      logger.debug(stringify(rule));
                       var result = evaluateExpressionOrString(rule.expression, tokens.slice());
                       if (result.success) {
                           var executeFunction = result.executeFunction || rule.executeFunction;
                           if (!executeFunction) {
-                              console.debug("rule matched, but no function to execute found, continue");
+                              logger.debug("rule matched, but no function to execute found, continue");
                               continue;
                           }
 
-                          console.debug("execute function with parameters: " + stringify(result.executeParameter.items));  
                           executeFunction(result.executeParameter);
                           break;
                       }
-                  }        
+                  }
               }
-
-
-
           }
 
           /**
-           * 
-           * @param {Expression} expression 
-           * @param {string[]} tokens 
+           *
+           * @param {Expression} expression
+           * @param {string[]} tokens
            * @returns {EvaluationResult}
            */
           function evaluateExpressionOrString(expression, tokens) {
@@ -451,10 +448,10 @@ actions:
                   return new EvaluationResult(false, tokens, null, null);
               }
 
-              console.debug("eval string: " + expression)
-              console.debug("token: " + tokens[0]);
+              logger.debug("eval string: " + expression)
+              logger.debug("token: " + tokens[0]);
               var hasMatch = tokens[0] === expression; //tokens[0].match(expression) != null;
-              console.debug("hasMatch: " + hasMatch)
+              logger.debug("hasMatch: " + hasMatch)
               return new EvaluationResult(hasMatch, tokens.slice(1), null, null);
           }
 
@@ -578,15 +575,15 @@ actions:
 
                   matchResult = checkSynonyms(allItems.slice());
 
-                  console.debug("get item by label: found matched synonyms: " + matchResult.remainingItems.length);
+                  logger.debug("get item by label: found matched synonyms: " + matchResult.remainingItems.length);
               }
 
               if (matchResult.remainingItems.length == 1) {
-                  console.debug("get item by label: success");
+                  logger.debug("get item by label: success");
                   return {matchedItem: matchResult.remainingItems[0].item, remainingTokens: tokens.slice(matchResult.tokenIndex)};
               }
 
-              console.debug("get item by label: fail");
+              logger.info("get item by label: fail");
               return null;
           }
 
@@ -630,7 +627,6 @@ actions:
                           checkedGroupNames.push(groupName);
                           groupStack.push(items.getItem(groupName));
                       }
-
                   });
               }
 

--- a/rule-template/cuevox.yaml
+++ b/rule-template/cuevox.yaml
@@ -50,8 +50,8 @@ actions:
           function alt(...expressions) {return new AlternativeExp(...expressions);}
           class AlternativeExp extends Expression {
               /**
-              * @param  {...Expression} expressions
-              */
+               * @param  {...Expression} expressions
+               */
               constructor(...expressions) {
                   super();
                   this.value = expressions;

--- a/test/ruleBasedInterpreter.test.js
+++ b/test/ruleBasedInterpreter.test.js
@@ -6,6 +6,10 @@ openhab.items = {
     getItemsByTag: jest.fn().mockReturnValue([]),
     getItem: jest.fn().mockReturnValue(null)
 };
+openhab.log = jest.fn().mockReturnValue({
+    info: console.log,
+    debug: console.debug
+});
 const { RuleBasedInterpreter, alt, seq, opt, cmd, itemLabel, itemProperties } = require("../lib/openHAB/ruleBasedInterpreter");
 
 let rbi = new RuleBasedInterpreter();


### PR DESCRIPTION
This switches the `console.debug` statements to use the logging facilities of OpenHab and rewires those log statements to still go to `console.` for unit tests.

I also removed trailing tabs and spaces from the `ruleBasedInterpreter.js`, however, seems the file had `CRLF` line endings and that is now converted to `LF`. The files seem to be a bit of a mix between `CRLF` and `LF` so I am unsure what you prefer here, let me know. I can convert the `ruleBasedInterpreter.js` back to `CRLF` if you want.